### PR TITLE
v1.0.18 Исправил warning в UploadRender для props hideTips в DropZone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modul/redux-form",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "package with fields for redux-form",
   "module": "./src",
   "scripts": {

--- a/src/renderControl/UploadRender.js
+++ b/src/renderControl/UploadRender.js
@@ -10,7 +10,7 @@ class UploadRender extends React.Component {
         this.focusator = new InputFocusable();
     }
 	render() {
-		const { input, meta, validator, disabled, children, onDropFile, className, ...props } = this.props;
+		const { input, meta, hideTips, validator, disabled, children, onDropFile, className, ...props } = this.props;
 		const { tooltip, addClassName } = validator;
 		const classNames = [className || '', addClassName || ''].join(' ');
 


### PR DESCRIPTION
![Screenshot 2019-07-15 at 16 05 31](https://user-images.githubusercontent.com/10406538/61205487-60691b00-a71a-11e9-88a3-fabd97e71388.png)

```javascript
  <UploadField {...props} hideTips={true}>
    {title}
  </UploadField>
```